### PR TITLE
Accomodate RcppAnnoy 0.16.2 or later with Annoy 1.17

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,0 +1,4 @@
+
+# Add this define with Rcpp 0.16.2 or later:  -D__RcppAnnoy_0_16_2__
+# Once that release is standard just remove the define here and its test (twice) in nn_parallel.h
+PKG_CXXFLAGS = -D__RcppAnnoy_0_16_2__

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,4 +1,0 @@
-
-# Add this define with Rcpp 0.16.2 or later:  -D__RcppAnnoy_0_16_2__
-# Once that release is standard just remove the define here and its test (twice) in nn_parallel.h
-PKG_CXXFLAGS = -D__RcppAnnoy_0_16_2__

--- a/src/annoy.h
+++ b/src/annoy.h
@@ -17,6 +17,14 @@
 #include "annoylib.h"
 #include "kissrandom.h"
 
+#if defined __RcppAnnoy_0_16_2__
+#ifdef ANNOYLIB_MULTITHREADED_BUILD
+  typedef AnnoyIndexMultiThreadedBuildPolicy AnnoyIndexThreadedBuildPolicy;
+#else
+  typedef AnnoyIndexSingleThreadedBuildPolicy AnnoyIndexThreadedBuildPolicy;
+#endif
+#endif
+
 template<class Distance>
 class Annoy {
 public:
@@ -30,8 +38,11 @@ public:
 
     typedef int32_t Index_t;
     typedef float Data_t;
+#if defined __RcppAnnoy_0_16_2__
+    typedef AnnoyIndex<Index_t, Data_t, Distance, Kiss64Random, AnnoyIndexThreadedBuildPolicy> _index;
+#else
     typedef AnnoyIndex<Index_t, Data_t, Distance, Kiss64Random> _index;
-
+#endif
     const std::vector<Index_t>& get_neighbors () const;
     const std::vector<Data_t>& get_distances () const;
 private:


### PR DESCRIPTION
Same mechanics as for `uwot` -- I added a trivial and empty `src/Makevars`.